### PR TITLE
Support timestamps with milliseconds

### DIFF
--- a/src/riemann/elastic.clj
+++ b/src/riemann/elastic.clj
@@ -27,7 +27,7 @@
       (clj-time.format/unparse formatter date))))
 
 (def ^{:private true} format-iso8601
-  (clj-time.format/with-zone (clj-time.format/formatters :date-time-no-ms)
+  (clj-time.format/with-zone (clj-time.format/formatters :date-time)
     clj-time.core/utc))
 
 (defn ^{:private true} iso8601 [event-s]


### PR DESCRIPTION
Use date-time formatter instead of date-time-no-ms. date-time also handles
timestamps without milliseconds, so we don't lose anything by using it.
