### PR TITLE
Support events that already have an ISO timestamp

### DIFF
--- a/src/riemann/elastic.clj
+++ b/src/riemann/elastic.clj
@@ -42,9 +42,13 @@
 
 (defn ^{:private true} stashify-timestamp [event]
   (->  (if-not (get event "@timestamp")
-         (let [time (:time event)]
-           (assoc event "@timestamp" (safe-iso8601 (long time))))
+         (let [isotime (:isotime event)]
+           (if-not isotime
+             (let [time (:time event)]
+               (assoc event "@timestamp" (safe-iso8601 (long time))))
+             (assoc event "@timestamp" isotime)))
          event)
+       (dissoc :isotime)
        (dissoc :time)
        (dissoc :ttl)))
 


### PR DESCRIPTION
The elasticsearch indexer now checks if events have a tag
called "isotime". If so, this value is used directly as
"@timestamp".

This makes it possible to assign the correct (source) timestamp directly
at riemann clients.
