### PR TITLE
Do not throw away whitespace or expand quoted globs in launcher

### DIFF
--- a/bin/kiries
+++ b/bin/kiries
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+# Avoid conflicts with plugins in the user's ~/.lein/profiles.clj
+export LEIN_HOME=${KIRIES_LEIN_HOME:-"$HOME/.lein-kiries"}
+
 exec bin/lein run -- "$@"

--- a/bin/kiries
+++ b/bin/kiries
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-bin/lein run -- $@
-
+exec bin/lein run -- "$@"


### PR DESCRIPTION
Also uses `exec` to replace the shell process with the `lein` launcher rather
than keeping it in the process table; this has a side effect of improving
signal handing (such that signals sent to the launcher process go directly to
kiries).