### PR TITLE
Fix portability issues, use of uberjar in preference to source in wrapper

### DIFF
--- a/bin/kiries
+++ b/bin/kiries
@@ -1,17 +1,100 @@
 #!/bin/bash
 
+### realpath and dependencies copyright Michael Kropat, used under the MIT license.
+### See https://github.com/mkropat/sh-realpath
+realpath() {
+    canonicalize_path "$(resolve_symlinks "$1")"
+}
+
+resolve_symlinks() {
+    _resolve_symlinks "$1"
+}
+
+_resolve_symlinks() {
+    _assert_no_path_cycles "$@" || return
+
+    local dir_context path
+    path=$(readlink -- "$1")
+    if [ $? -eq 0 ]; then
+        dir_context=$(dirname -- "$1")
+        _resolve_symlinks "$(_prepend_dir_context_if_necessary "$dir_context" "$path")" "$@"
+    else
+        printf '%s\n' "$1"
+    fi
+}
+
+_prepend_dir_context_if_necessary() {
+    if [ "$1" = . ]; then
+        printf '%s\n' "$2"
+    else
+        _prepend_path_if_relative "$1" "$2"
+    fi
+}
+
+_prepend_path_if_relative() {
+    case "$2" in
+        /* ) printf '%s\n' "$2" ;;
+         * ) printf '%s\n' "$1/$2" ;;
+    esac
+}
+
+_assert_no_path_cycles() {
+    local target path
+
+    target=$1
+    shift
+
+    for path in "$@"; do
+        if [ "$path" = "$target" ]; then
+            return 1
+        fi
+    done
+}
+
+canonicalize_path() {
+    if [ -d "$1" ]; then
+        _canonicalize_dir_path "$1"
+    else
+        _canonicalize_file_path "$1"
+    fi
+}
+
+_canonicalize_dir_path() {
+    (cd "$1" 2>/dev/null && pwd -P)
+}
+
+_canonicalize_file_path() {
+    local dir file
+    dir=$(dirname -- "$1")
+    file=$(basename -- "$1")
+    (cd "$dir" 2>/dev/null && printf '%s/%s\n' "$(pwd -P)" "$file")
+}
+### End content copyright Michael Kropat
+
 shopt -s nullglob
 
 # Avoid conflicts with plugins in the user's ~/.lein/profiles.clj
 export LEIN_HOME=${KIRIES_LEIN_HOME:-"$HOME/.lein-kiries"}
 
 # Find location of executable; move to base
-source_dir=$(readlink -f "$BASH_SOURCE")
-cd "${source_dir%/bin/*}" || exit
+bin_dir=$(realpath "$BASH_SOURCE" 2>/dev/null)
+source_dir=${bin_dir%/bin/*}
+cd "$source_dir" || exit
 
-potential_jars=( target/kiries-*standalone.jar )
-if (( ${#potential_jars[@]} == 1 )); then
-    exec java -cp "/usr/share/kiries/resources:$potential_jars" kiries.core "$@"
-else
+# If a source directory exists, honor it
+if [[ -e src ]]; then
     exec bin/lein run -- "$@"
 fi
+
+# Otherwise, use the newest available uberjar
+potential_jars=( target/kiries-*standalone.jar )
+if (( ${#potential_jars[@]} == 0 )); then
+    echo "ERROR: No source directory, and no uberjar found" >&2
+    exit 1
+fi
+
+newest_jar=${potential_jars[0]}
+for j in "${potential_jars[@]}"; do
+    [[ $j -nt $newest_jar ]] && newest_jar=$j
+done
+exec java -cp "$source_dir/resources:$newest_jar" kiries.core "$@"

--- a/bin/kiries
+++ b/bin/kiries
@@ -97,4 +97,18 @@ newest_jar=${potential_jars[0]}
 for j in "${potential_jars[@]}"; do
     [[ $j -nt $newest_jar ]] && newest_jar=$j
 done
-exec java -cp "$source_dir/resources:$newest_jar" kiries.core "$@"
+
+# Following ant conventions, -X* is a JVM argument as opposed to a kiries
+# argument.  JVM arguments that need to start with -X should thus be passed
+# with -X-X...
+jvm_args=( )
+args=( )
+for arg; do
+    if [[ $arg = -X* ]]; then
+      jvm_args+=( "${arg#-X}" )
+    else
+      args+=( "$arg" )
+    fi
+done
+
+exec java -cp "$source_dir/resources:$newest_jar" "${jvm_args[@]}" kiries.core "${args[@]}"


### PR DESCRIPTION
Resolves issues introduced with the Arch packaging introduction.

- Don't rely on GNU readlink; instead, use realpath implementation from Mike Kropat (released under MIT license). Fixes OS X support.
- Always use "lein run" if a source directory is present. If not present, use the most recent uberjar (if more than one exists). Replaces prior behavior of always using a built uberjar if one and only one exists.
- Don't assume packaging in /usr/share/kiries when running from an uberjar