### PR TITLE
Prefix JVM stats

### DIFF
--- a/config/jvm-metrics.config
+++ b/config/jvm-metrics.config
@@ -5,11 +5,11 @@
               (map
                (fn [e]
                  (riemann.core/stream! @riemann.config/core e))
-               (kiries.jvm/vm-metrics)))))
+               (kiries.jvm/vm-metrics :prefix "kiries")))))
 
 ;; Log all JVM events to the jvm-metrics index
 (streams
- (where (service #"^jvm")
+ (where (service #"^kiries.jvm")
         (rollup 1 5
                 (elastic/es-index "jvm-metrics"
                                   :timestamping :day

--- a/src/kiries/jvm.clj
+++ b/src/kiries/jvm.clj
@@ -3,13 +3,6 @@
 
 ;; ----------------------------------------
 
-(defn ^:private fixup-prefix [prefix default-prefix]
-  (if prefix
-    (if (.endsWith prefix ".")
-      prefix
-      (str prefix "."))
-    default-prefix))
-
 (def clock (com.yammer.metrics.core.Clock/defaultClock))
 (def vm-stats (com.yammer.metrics.core.VirtualMachineMetrics/getInstance))
 
@@ -17,7 +10,11 @@
   (let [epoch
         (long (/ (.time clock) 1000))
 
-        prefix (fixup-prefix prefix "")
+        prefix (if prefix
+                  (if (or (.endsWith prefix ".") (empty? prefix))
+                    prefix
+                    (str prefix "."))
+                  "")
 
         metrics
         (concat


### PR DESCRIPTION
Since more than one JVM can be run on a single machine, providing a means to
distinguish them is a Good Thing if this code will used by processes other than
kiries itself.