### PR TITLE
Upgrade to riemann 0.2.9

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -1,0 +1,1 @@
+{:dev {:dependencies [[org.clojure/tools.nrepl "0.2.10"]]}}

--- a/project.clj
+++ b/project.clj
@@ -31,6 +31,7 @@
                  [com.taoensso/carmine "2.6.2"]
 
                  ;; Resolve dependency version conflicts explicitly
+                 [org.clojure/tools.nrepl "0.2.10"]
                  [org.clojure/tools.reader "0.8.10"]
                  [com.taoensso/encore "1.11.2"]
                  [org.codehaus.plexus/plexus-utils "3.0"]

--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,13 @@
   :description "A bundled deployment of Kibana, Riemann, and ElasticSearch"
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/tools.cli "0.2.4"]
-                 [clj-logging-config "1.9.10"]
+
+                 [riemann "0.2.9"]
+
                  [clj-json "0.5.3"]
-                 [slingshot "0.10.3"]
+                 [slingshot "0.12.1"]
                  
-                 [riemann "0.2.5"]
-                 [clj-time "0.7.0"]
+                 [clj-time "0.9.0"]
                  [clojurewerkz/elastisch "1.5.0-beta3"]
                  [org.elasticsearch/elasticsearch "1.1.1"]
                  
@@ -17,17 +18,25 @@
                  [compojure "1.1.8"]
                  [hiccup "1.0.5"]
                  [org.markdownj/markdownj "0.3.0-1.0.2b4"]
-                 [ring/ring-core "1.2.0"]
-                 [ring/ring-devel "1.2.0"]
-                 [ring/ring-jetty-adapter "1.2.0"]
+                 [ring/ring-core "1.2.2"]
+                 [ring/ring-devel "1.2.2"]
+                 [ring/ring-jetty-adapter "1.2.2"]
 
                  ;; integration tools
-                 [clj-http "0.9.1"]
-                 [cheshire "5.3.1"]
+                 [clj-http "1.0.1"]
+                 [cheshire "5.5.0"]
                  [clojure-csv/clojure-csv "2.0.1"]
 
                  ;; Redis integration
-                 [com.taoensso/carmine "2.6.2"]]
+                 [com.taoensso/carmine "2.6.2"]
+
+                 ;; Resolve dependency version conflicts explicitly
+                 [org.clojure/tools.reader "0.8.10"]
+                 [com.taoensso/encore "1.11.2"]
+                 [org.codehaus.plexus/plexus-utils "3.0"]
+                 [com.taoensso/nippy "2.7.0"]
+                 [clj-logging-config "1.9.12"]
+                ]
   
   :resource-paths ["resources"]
   ;;:jar-exclusions [#"^config"]


### PR DESCRIPTION
Forces some dependency updates; in particularly, things explode vigorously without revving cheshire to 0.2.9.

Went through conflicts in "lein deps :tree" and resolved them explicitly.