### PR TITLE
Use our forked version of Riemann

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,14 @@
 (defproject kiries "1.0.0-SNAPSHOT"
   :description "A bundled deployment of Riemann, and ElasticSearch"
   :dependencies [[clj-json "0.5.3"]
-                 [clojurewerkz/elastisch "2.2.2"]
                  [com.taoensso/carmine "2.14.0"]
+                 [clojurewerkz/elastisch "2.2.2"
+                  :exclusions [clj-http]]
+                 [com.taoensso/carmine "2.16.0"]
                  [org.clojure/clojure "1.8.0"]
-                 [org.clojure/tools.reader "1.0.0-beta3"]
-                 [riemann "0.2.11"]]
+                 [cheshire "5.7.0"]
+                 [org.clojure/tools.reader "1.0.3"]
+                 [org.clojars.jcsims/riemann "0.2.15"]]
   :main riemann.bin
   :profiles {:uberjar {:aot :all,}}
   :aliases {"server" ["trampoline" "run" "-m" "riemann.bin" "config/riemann.config"]})


### PR DESCRIPTION
This adds:
 - a `:message-formatter` key to `riemann.hipchat/hipchat` that
   will override the default `format-message` fn
 - an `:event-url` key to `riemann.pagerduty/pagerduty` will override the
   default pagerduty notification URL.