### PR TITLE
Add redhat repository to :repositories in project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,6 +9,7 @@
                  [cheshire "5.7.0"]
                  [org.clojure/tools.reader "1.0.3"]
                  [org.clojars.jcsims/riemann "0.2.16"]]
+  :repositories [["redhat" "https://maven.repository.redhat.com/ga/"]]
   :main riemann.bin
   :profiles {:uberjar {:aot :all,}}
   :aliases {"server" ["trampoline" "run" "-m" "riemann.bin" "config/riemann.config"]})


### PR DESCRIPTION
Leiningen correctly resolves transitive dependencies stored in repositories specified in the POMs/descriptors of intermediate items in the dependency tree; however, this is not true of several other Aether-based tools for dependency-tree interaction/recording.

Adding the "redhat" repository (needed for com.googlecode/jsendnsca-core to be found as a dependency of cljr-nsca) thus unbreaks some supplementary/3rd-party tooling.