### PR TITLE
Pass on options to clj-http from es-connect

### DIFF
--- a/src/kiries/elastic.clj
+++ b/src/kiries/elastic.clj
@@ -97,12 +97,21 @@
        (map #(elastic-event % massage))))
 
 (defn es-connect
-  "Connects to the ElasticSearch node.  The optional argument is a url
-  for the node, which defaults to `http://localhost:9200`.  This must
-  be called before any es-* functions can be used."
-  [& argv]
-  (esr/connect (or (first argv) "http://localhost:9200")
-               {:content-type "application/x-ndjson"}))
+  "Connects to the ElasticSearch node.
+
+  The first optional argument is a url for the node, which defaults to
+  `http://localhost:9200`.  The second optional arg is a map of
+  options to be passed to clj-http.
+
+  This must be called before any es-* functions can be used."
+  ([]
+   (es-connect "http://localhost:9200"))
+  ([host]
+   (es-connect host nil))
+  ([host http-opts]
+   (esr/connect host
+                (merge {:content-type "application/x-ndjson"}
+                       http-opts))))
 
 (defn- parse-1x-bulk-results [res]
   {:total (count (:items res))


### PR DESCRIPTION
Currently, there's no way to set things like connection or socket timeouts when indexing to ES. This allows us to pass those in.

E.g.:
```clojure
(elastic/es-connect elastic-addr
                    {:socket-timeout 30000
                     :connection-timeout 30000})
```
